### PR TITLE
Update actions, deduplicate tests

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -46,9 +46,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew build -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -67,7 +67,16 @@ jobs:
           name: assessment-api-jar
           path: assessment-service/build/libs/assessment-service-${{ steps.capture_version.outputs.app_version }}.jar
 
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: assessment-service/build/reports/checkstyle
+          retention-days: 14
+
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
@@ -75,6 +84,7 @@ jobs:
           retention-days: 14
 
       - name: Upload jacoco coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -67,6 +67,20 @@ jobs:
           name: assessment-api-jar
           path: assessment-service/build/libs/assessment-service-${{ steps.capture_version.outputs.app_version }}.jar
 
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: assessment-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: assessment-service/build/reports/jacoco
+          retention-days: 14
+
   ecr:
     needs: [ build-test-publish, define-image-tag ]
     runs-on: ubuntu-latest

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -42,27 +42,19 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build -Pversion=${{ steps.capture_version.outputs.app_version }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
-      - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest --tests '*IntegrationTest'
+      - name: Integration test
+        run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew publish -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -55,10 +55,12 @@ jobs:
           VERSION=$(grep "version=" gradle.properties | cut -d'=' -f2)
           echo "app_version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Captured version: $VERSION"
+
       - name: Publish package
         run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: upload jarfile
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -40,10 +40,14 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build JAR with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: assemble
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew assemble
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Capture version
         shell: bash
         id: capture_version
@@ -52,9 +56,7 @@ jobs:
           echo "app_version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Captured version: $VERSION"
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: upload jarfile

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -60,7 +60,16 @@ jobs:
           path: assessment-service/build/test-results
           retention-days: 14
 
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: assessment-service/build/reports/checkstyle
+          retention-days: 14
+
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
@@ -68,11 +77,13 @@ jobs:
           retention-days: 14
 
       - name: Upload jacoco coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report
           path: assessment-service/build/reports/jacoco
           retention-days: 14
+
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -35,9 +35,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
@@ -49,6 +52,27 @@ jobs:
 
       - name: Update version
         run: ./gradlew release -Prelease.useAutomaticVersion=true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: assessment-service/build/test-results
+          retention-days: 14
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: assessment-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: assessment-service/build/reports/jacoco
+          retention-days: 14
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -31,22 +31,16 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
-      - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest --tests '*IntegrationTest'
+      - name: Integration test
+        run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Set to github user
         run: |
@@ -54,9 +48,7 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
 
       - name: Update version
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: release -Prelease.useAutomaticVersion=true
+        run: ./gradlew release -Prelease.useAutomaticVersion=true
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -50,7 +50,16 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: assessment-service/build/reports/checkstyle
+          retention-days: 14
+
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
@@ -58,6 +67,7 @@ jobs:
           retention-days: 14
 
       - name: Upload jacoco coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -50,13 +50,6 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: assessment-service/build/test-results
-          retention-days: 14
-
       - name: Upload test report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -32,9 +32,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
@@ -46,6 +49,27 @@ jobs:
         run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: assessment-service/build/test-results
+          retention-days: 14
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: assessment-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: assessment-service/build/reports/jacoco
+          retention-days: 14
 
   vulnerability-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -28,32 +28,22 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
-
-      - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest --tests '*IntegrationTest'
+      - name: Integration test
+        run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Update snapshot version
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: updateSnapshotVersion
+        run: ./gradlew updateSnapshotVersion
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please ensure this matches the command used by the [pr-merge-main](.github/workf
 workflow to maintain consistency.
 
 ```shell
-snyk monitor --org=legal-aid-agency --all-projects --exclude=build,generated
+snyk monitor --org=legal-aid-agency --all-projects --exclude=build,generated --target-reference=main
 ```
 
 You should then see the new vulnerability in the LAA Dashboard, otherwise it is a new

--- a/assessment-service/build.gradle
+++ b/assessment-service/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 
     //Used for integration tests
-    implementation platform('org.testcontainers:testcontainers-bom:1.19.3')
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.20.4')
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:oracle-free'
@@ -32,6 +32,8 @@ dependencies {
 
 test {
     useJUnitPlatform()
+
+    finalizedBy jacocoTestReport
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25-c6d1344-SNAPSHOT' apply false
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25-c6d1344-SNAPSHOT' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25' apply false
 }
 
 subprojects {


### PR DESCRIPTION
* Bump to latest SB common library version
  * Fixed bug where duplicate unit tests would run twice in pipelines (`build` would run tests, followed by `jacocoTestVerification`)
* Workflows
  * Replace deprecated `gradle-build-action` with `setup-gradle` action
  * Upload checkstyle, test and jacoco coverage artifacts
  * Fixed bug where test coverage verification would run without jacoco report (effectively always passing)