### PR TITLE
Fix: Action permissions

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.pull_request.merged == true }}
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
     permissions:
-      contents: read
+      contents: write
       packages: write
     with:
       integration_test_task: "integrationTest --tests '*IntegrationTest'"


### PR DESCRIPTION
Grant `contents: write` permissions when building main to be able to create a release