### PR TITLE
Fix: Update workflow permissions

### DIFF
--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -18,7 +18,7 @@ jobs:
   build-and-publish-snapshot:
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
     permissions:
-      contents: read
+      contents: write
       packages: write
     with:
       integration_test_task: "integrationTest --tests '*IntegrationTest'"

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -27,7 +27,7 @@ jobs:
       checkstyle_report_path: 'assessment-service/build/reports/checkstyle'
       jacoco_coverage_report_path: 'assessment-service/build/reports/jacoco'
     secrets:
-      gh_token: ${{ secrets.REPO_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   vulnerability-report:
     if: ${{ github.event.pull_request.merged == true }}

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -39,7 +39,7 @@ jobs:
     needs: [ define-feature-version ]
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
     permissions:
-      contents: read
+      contents: write
       packages: write
     with:
       integration_test_task: "integrationTest --tests '*IntegrationTest'"

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -19,7 +19,7 @@ jobs:
   assemble-and-publish:
     uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/gradle-build-and-publish.yml@v1
     permissions:
-      contents: read
+      contents: write
       packages: write
     with:
       build_command: 'assemble'


### PR DESCRIPTION
- Update all pipelines with new write permissions required by the `gradle-build-and-publish` action.
- Revert back to using `GITHUB_TOKEN` to allow release commits to be made directly on the main branch